### PR TITLE
fix: discord id generation

### DIFF
--- a/chiabot.dart
+++ b/chiabot.dart
@@ -83,7 +83,7 @@ main(List<String> args) async {
 
       log.info("Generating new report #${counter}");
 
-      cache.init(config.parseLogs, config.userNumber);
+      cache.init(config.parseLogs);
       Log chiaLog = new Log(chiaDebugPath, cache, config.parseLogs);
 
       var client = (config.type == ClientType.Farmer)

--- a/lib/cache.dart
+++ b/lib/cache.dart
@@ -42,7 +42,7 @@ class Cache {
     }
   }
 
-  void init([bool parseLogs = false, int userNumber = 1]) {
+  void init([bool parseLogs = false]) {
     //Tells log parser when it should stop parsing
     parseUntil =
         DateTime.now().subtract(Duration(days: 1)).millisecondsSinceEpoch;

--- a/lib/cache.dart
+++ b/lib/cache.dart
@@ -44,10 +44,6 @@ class Cache {
   }
 
   void init([bool parseLogs = false, int userNumber = 1]) {
-    //populates id[] with random ids based on number of users provided by config
-    ids = [];
-    for (int i = 0; i < userNumber; i++) ids.add(Uuid().v4());
-
     //Tells log parser when it should stop parsing
     parseUntil =
         DateTime.now().subtract(Duration(days: 1)).millisecondsSinceEpoch;
@@ -57,12 +53,6 @@ class Cache {
       save(); //creates cache file if doesnt exist
     else
       load(parseLogs); //chiabot_cache.json
-
-    //generates new ids
-    if (userNumber > ids.length) {
-      int newIds = userNumber - ids.length;
-      for (int i = 0; i < newIds; i++) ids.add(Uuid().v4());
-    }
 
     save();
   }

--- a/lib/cache.dart
+++ b/lib/cache.dart
@@ -3,7 +3,6 @@ import 'dart:io' as io;
 import 'dart:convert';
 
 import 'package:logging/logging.dart';
-import 'package:uuid/uuid.dart';
 
 import 'package:chiabot/plot.dart';
 import 'package:chiabot/log/filter.dart';

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'package:logging/logging.dart';
 import 'package:dart_console/dart_console.dart';
 import 'package:qr/qr.dart';
+import 'package:uuid/uuid.dart';
 
 import 'package:chiabot/cache.dart';
 
@@ -102,6 +103,18 @@ class Config {
     if (type == ClientType.Farmer &&
         (cache.binPath == null || !io.File(cache.binPath).existsSync()))
       await _askForBinPath();
+
+    /** Generate Discord Id's */
+    if (cache.ids.length != userNumber) {
+      if (userNumber > cache.ids.length) {
+        // More Id's (add)
+        int newIds = userNumber - cache.ids.length;
+        for (int i = 0; i < newIds; i++) cache.ids.add(Uuid().v4());
+      } else if (userNumber < cache.ids.length) {
+        // Less Id's (fresh list)
+        for (int i = 0; i < userNumber; i++) cache.ids.add(Uuid().v4());
+      }
+    }
 
     _info(); //shows first screen info with qr code, id, !chia, etc.
   }

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -114,6 +114,7 @@ class Config {
         // Less Id's (fresh list)
         for (int i = 0; i < userNumber; i++) cache.ids.add(Uuid().v4());
       }
+      cache.save();
     }
 
     _info(); //shows first screen info with qr code, id, !chia, etc.


### PR DESCRIPTION
### Problem
After changing the number of discord users, chiabot requires two executions to output the links to the terminal.

---
### Solution
Since config is handling the output of the discord links, it makes sense for config to also create the users.

Otherwise, if we want config to purely be handling config loading, we should move both the `user creation` as well as the `discord links output` to a non-cache/non-config file.